### PR TITLE
Error templates - whitespace characters and vertical align of line numbers

### DIFF
--- a/src/themes/error.dark.mustache
+++ b/src/themes/error.dark.mustache
@@ -687,11 +687,7 @@ pre[class*="language-"] {
                   data-line="{{line}}"
                   data-file="Open File: {{file}}"
                   data-method="{{method}}:"
-                  data-line-column="{{line}}:{{column}}">
-                   {{ context.pre }}
-                   {{ context.line }}
-                   {{ context.post }}
-                </div>
+                  data-line-column="{{line}}:{{column}}">{{ context.pre }}&#10;{{ context.line }}&#10;{{ context.post }}</div>
               </div>
             {{/frames}}
           </div>

--- a/src/themes/error.dark.mustache
+++ b/src/themes/error.dark.mustache
@@ -247,7 +247,7 @@ pre[class*="language-"] {
     .line-numbers .line-numbers-rows {
       position: absolute;
       pointer-events: none;
-      top: 0;
+      top: -5px;
       font-size: 100%;
       left: -3.8em;
       width: 3em; /* works for line-numbers below 1000 lines */

--- a/src/themes/error.default.mustache
+++ b/src/themes/error.default.mustache
@@ -610,11 +610,7 @@
                   data-line="{{line}}"
                   data-file="Open File: {{file}}"
                   data-method="{{method}}:"
-                  data-line-column="{{line}}:{{column}}">
-                   {{ context.pre }}
-                   {{ context.line }}
-                   {{ context.post }}
-                </div>
+                  data-line-column="{{line}}:{{column}}">{{ context.pre }}&#10;{{ context.line }}&#10;{{ context.post }}</div>
               </div>
             {{/frames}}
           </div>

--- a/src/themes/error.default.mustache
+++ b/src/themes/error.default.mustache
@@ -172,7 +172,7 @@
     .line-numbers .line-numbers-rows {
       position: absolute;
       pointer-events: none;
-      top: 0;
+      top: -5px;
       font-size: 100%;
       left: -3.8em;
       width: 3em; /* works for line-numbers below 1000 lines */

--- a/src/themes/error.light.mustache
+++ b/src/themes/error.light.mustache
@@ -610,11 +610,7 @@
                   data-line="{{line}}"
                   data-file="Open File: {{file}}"
                   data-method="{{method}}:"
-                  data-line-column="{{line}}:{{column}}">
-                   {{ context.pre }}
-                   {{ context.line }}
-                   {{ context.post }}
-                </div>
+                  data-line-column="{{line}}:{{column}}">{{ context.pre }}&#10;{{ context.line }}&#10;{{ context.post }}</div>
               </div>
             {{/frames}}
           </div>

--- a/src/themes/error.light.mustache
+++ b/src/themes/error.light.mustache
@@ -172,7 +172,7 @@
     .line-numbers .line-numbers-rows {
       position: absolute;
       pointer-events: none;
-      top: 0;
+      top: -5px;
       font-size: 100%;
       left: -3.8em;
       width: 3em; /* works for line-numbers below 1000 lines */


### PR DESCRIPTION
Hi,

I made some small changes in error templates.  
Firstly I removed whitespace in div with source code of given error frame. Newlines between parts of source code was replace by unicode characters. Now highlight of error should be point to correct line.

Secondly, I tuned styles for line numbers, so now they should be more vertical centered.

Below screenshots attached with new results. 
![nestjs-flub-dark](https://user-images.githubusercontent.com/34690782/63543241-a6d44580-c522-11e9-90b3-029a33959ba2.jpg)
![nestjs-flub-light](https://user-images.githubusercontent.com/34690782/63543242-a6d44580-c522-11e9-9772-d88db948589a.jpg)

Take a look, and tell me what you think ;)

Best regards,
Lukasz

